### PR TITLE
fix: Change the 'Untitled' documents title language when the user changes the application language

### DIFF
--- a/src/components/TabTextPro.tsx
+++ b/src/components/TabTextPro.tsx
@@ -17,12 +17,13 @@ interface Document {
   wordCount: number;
   history: string[];
   historyIndex: number;
+  isUntitled?: boolean; // New property to track untitled documents
 }
 
 const TabTextPro = () => {
   const { language, t, changeLanguage } = useLanguage();
   const [documents, setDocuments] = useState<Document[]>([
-    { id: '1', title: t.untitledDocument, content: '', saved: true, wordCount: 0, history: [''], historyIndex: 0 }
+    { id: '1', title: t.untitledDocument, content: '', saved: true, wordCount: 0, history: [''], historyIndex: 0, isUntitled: true }
   ]);
   const [activeTab, setActiveTab] = useState('1');
   const [darkMode, setDarkMode] = useState(() => {
@@ -52,6 +53,19 @@ const TabTextPro = () => {
     localStorage.setItem('tabtext-theme', darkMode ? 'dark' : 'light');
   }, [darkMode]);
 
+
+  useEffect(() => {
+    setDocuments(docs => 
+      docs.map(doc => {
+        // Only update title for untitled documents
+        if (doc.isUntitled) {
+          return { ...doc, title: t.untitledDocument };
+        }
+        return doc;
+      })
+    );
+  }, [t.untitledDocument]);
+
   const createNewDocument = () => {
     const newId = Date.now().toString();
     const newDoc: Document = {
@@ -61,7 +75,8 @@ const TabTextPro = () => {
       saved: true,
       wordCount: 0,
       history: [''],
-      historyIndex: 0
+      historyIndex: 0,
+      isUntitled: true // mark as untitled
     };
     setDocuments([...documents, newDoc]);
     setActiveTab(newId);
@@ -124,9 +139,9 @@ const TabTextPro = () => {
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
 
-    // Update document title and mark as saved
+    // Update document title and mark as saved (is not untitled anymore)
     setDocuments(docs => 
-      docs.map(d => d.id === activeTab ? { ...d, title: fileName, saved: true } : d)
+      docs.map(d => d.id === activeTab ? { ...d, title: fileName, saved: true, isUntitled: false } : d)
     );
     
     setIsSaveAsOpen(false);
@@ -157,7 +172,8 @@ const TabTextPro = () => {
         saved: true,
         wordCount: content.trim().split(/\s+/).filter(word => word.length > 0).length,
         history: [content],
-        historyIndex: 0
+        historyIndex: 0,
+        isUntitled: false 
       };
       setDocuments([...documents, newDoc]);
       setActiveTab(newId);

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -6,7 +6,7 @@ const LANGUAGE_STORAGE_KEY = 'tabtext-language';
 export const useLanguage = () => {
   const [language, setLanguage] = useState<Language>(() => {
     const saved = localStorage.getItem(LANGUAGE_STORAGE_KEY);
-    if (saved && (saved === 'en' || saved === 'it')) {
+    if (saved && ['en', 'it', 'es', 'ru', 'zh'].includes(saved)) {
       return saved as Language;
     }
     
@@ -14,6 +14,15 @@ export const useLanguage = () => {
     const browserLang = navigator.language.toLowerCase();
     if (browserLang.startsWith('it')) {
       return 'it';
+    }
+    if (browserLang.startsWith('es')) {
+      return 'es';
+    }
+    if (browserLang.startsWith('ru')) {
+      return 'ru';
+    }
+    if (browserLang.startsWith('zh')) {
+      return 'zh';
     }
     return 'en';
   });


### PR DESCRIPTION
Good first issue

This PR contains the solution of an issue in the language changing feature. Specifically, when the user opens a new document the defeault title is "Untitled Document" but if the user wanted to chenge the aplication language in that moment the document title didn't change, it still named with the previus language until the user refresh the page. Now, that issue was solved, when the user change the aplication language the Untitled documents default title change their language too.

<img width="1920" height="167" alt="Captura desde 2025-07-18 12-26-46" src="https://github.com/user-attachments/assets/9413f334-da43-44a3-aef1-277c4327b6e7" />

Now if I change the language the default document title changes too

<img width="1920" height="167" alt="Captura desde 2025-07-18 12-35-14" src="https://github.com/user-attachments/assets/affd985e-534c-4b4d-ad7a-d47155537a1b" />

   